### PR TITLE
Read Token and Project from Settings File

### DIFF
--- a/GitPrune.csproj
+++ b/GitPrune.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0096" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Octokit" Version="0.50.0" />
   </ItemGroup>
 

--- a/GithubManager.cs
+++ b/GithubManager.cs
@@ -4,19 +4,21 @@ using Octokit;
 
 public class GithubManager
 {
-    public GithubManager()
+    public GithubManager(Settings settings)
     {
         _client = new GitHubClient(new ProductHeaderValue("GitPrune"));
-        _client.Credentials = new(Secrets.GithubToken);
+        _client.Credentials = new(settings.GithubToken);
+        _settings = settings;
     }
 
     readonly GitHubClient _client;
+    readonly Settings _settings;
 
     public async Task<PullRequest> FindClosedPullRequestFromBranchName(string branchName)
     {
-        var pullRequest = await _client.PullRequest.GetAllForRepository(Secrets.GithubOwner, Secrets.GithubRepo, new PullRequestRequest() {
+        var pullRequest = await _client.PullRequest.GetAllForRepository(_settings.GithubOwner, _settings.GithubRepo, new PullRequestRequest() {
             State = ItemStateFilter.Closed,
-            Head = $"{Secrets.GithubOwner}:{branchName}",
+            Head = $"{_settings.GithubOwner}:{branchName}",
         });
 
         return pullRequest?.FirstOrDefault();

--- a/Program.cs
+++ b/Program.cs
@@ -9,16 +9,15 @@ bool isCommitting = !args.Contains("-i");
 
 const int _BULK_GITHUB_REQUESTS = 5;
 string[] _BRANCHES_TO_EXCLUDE = new string[] { "master", "main", "dev", "development" };
-var _githubManager = new GithubManager();
 
 int cursorRow = -1;
-
-Console.WriteLine("Finding Branches to Prune...");
 
 var workingDirectory = Directory.GetCurrentDirectory();
 if (args.Length > 0 && Directory.Exists(args[0])) {
     workingDirectory = args[0];
 }
+
+Console.WriteLine("Finding Branches to Prune...");
 
 if (!Repository.IsValid(workingDirectory)) {
     Console.WriteLine("You are not in a git directory.");
@@ -26,6 +25,29 @@ if (!Repository.IsValid(workingDirectory)) {
 }
 
 using var repo = new Repository(workingDirectory);
+
+// Check the config
+var settings = SettingsManager.GetSettings(repo.Info.Path);
+
+if (settings == null
+    || string.IsNullOrEmpty(settings.GithubToken)
+    || string.IsNullOrEmpty(settings.GithubOwner)
+    || string.IsNullOrEmpty(settings.GithubRepo)) {
+        Console.WriteLine("You have not intialized any settings file or the settings file is corrupt.");
+        Console.WriteLine("Attempting to create settings file...");
+
+        var settingsPath = SettingsManager.CreateEmptySettings(repo.Info.Path);
+        if (settingsPath.GlobalSettingsPath != null)
+            Console.WriteLine($"Global settings file created: {settingsPath.GlobalSettingsPath}");
+
+        if (settingsPath.LocalSettingsPath != null)
+            Console.WriteLine($"Local settings file created: {settingsPath.LocalSettingsPath}");
+
+        Console.WriteLine("Please open your settings file and fill out the settings before running git prune.");
+        return;
+    }
+
+var _githubManager = new GithubManager(settings);
 
 var localBranches = repo.Branches
     .Where(b => !b.IsRemote && !_BRANCHES_TO_EXCLUDE.Contains(b.FriendlyName))

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,0 +1,111 @@
+using System.IO;
+using System;
+using Newtonsoft.Json;
+
+public static class SettingsManager
+{
+    const string _SETTINGS_NAME = "prune_config.json";
+
+    static readonly JsonSerializerSettings _defaultJsonSettings = new JsonSerializerSettings
+    {
+        NullValueHandling = NullValueHandling.Ignore,
+        MissingMemberHandling = MissingMemberHandling.Ignore,
+    };
+    
+    public static Settings GetSettings(string baseRepoPath)
+    {
+        var localSettingsPath = Path.Combine(baseRepoPath, _SETTINGS_NAME);
+        var globalSettingsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, _SETTINGS_NAME);
+
+        // Find the local settings path
+        if (!File.Exists(localSettingsPath))
+        {
+            if (File.Exists(Path.Combine(baseRepoPath, ".github", _SETTINGS_NAME)))
+                localSettingsPath = Path.Combine(baseRepoPath, ".github", _SETTINGS_NAME);
+            else
+                localSettingsPath = string.Empty;
+        }
+
+        // Find the global settings path
+        if (!File.Exists(globalSettingsPath))
+            globalSettingsPath = string.Empty;
+        
+        var globalSettings = string.IsNullOrEmpty(globalSettingsPath)
+            ? null
+            : _ReadConfigFile(globalSettingsPath);
+
+        var localSettings = string.IsNullOrEmpty(localSettingsPath)
+            ? null
+            : _ReadConfigFile(localSettingsPath);
+
+        if (globalSettings == null)
+            return localSettings;
+        else if (localSettings == null)
+            return globalSettings;
+        else
+            return _GetCombinedSettings(localSettings, globalSettings);
+    }
+
+    public static (string GlobalSettingsPath, string LocalSettingsPath) CreateEmptySettings(string baseRepoPath)
+    {
+        var jsonSettings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Include,
+            Formatting = Formatting.Indented,
+        };
+
+        var globalJson = JsonConvert.SerializeObject(new { GithubToken = "" }, jsonSettings);
+        var localJson = JsonConvert.SerializeObject(new { GithubOwner = "", GithubRepo = "" }, jsonSettings);
+
+        var localSettingsPath = Path.Combine(baseRepoPath, _SETTINGS_NAME);
+        var globalSettingsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, _SETTINGS_NAME);
+
+        try
+        {
+            if (!File.Exists(globalSettingsPath))
+                File.WriteAllText(globalSettingsPath, globalJson);
+            else 
+                globalSettingsPath = null;
+        }
+        catch (IOException) {}
+
+        try
+        {
+            if (!File.Exists(localSettingsPath))
+                File.WriteAllText(localSettingsPath, localJson);
+            else
+                localSettingsPath = null;
+        }
+        catch (IOException) {}
+
+        return (globalSettingsPath, localSettingsPath);
+    }
+
+    static Settings _ReadConfigFile(string configPath)
+    {
+        try
+        {
+            var json = File.ReadAllText(configPath);
+            return JsonConvert.DeserializeObject<Settings>(json, _defaultJsonSettings);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+    
+    static Settings _GetCombinedSettings(Settings localSettings, Settings globalSettings) =>
+        new Settings
+        {
+            GithubToken = localSettings.GithubToken ?? globalSettings.GithubToken,
+            GithubOwner = localSettings.GithubOwner ?? globalSettings.GithubOwner,
+            GithubRepo = localSettings.GithubRepo ?? globalSettings.GithubRepo
+        };
+}
+
+public record Settings
+{
+    public string GithubToken { get; set; }
+    public string GithubOwner { get; set; }
+    public string GithubRepo { get; set; }
+}


### PR DESCRIPTION
There should be 2 settings file: a global and a local. The local settings file overrrides the global one, but if none are available both will be created (the global one for the token and the local one in the `.git` folder with the github owner and repo)

This also removes the "Secrets" file, as there are currently no secrets. This might return though if we want to implement OAuth and have a client secret