### PR TITLE
Auto-extract settings from remoteURL

### DIFF
--- a/GithubManager.cs
+++ b/GithubManager.cs
@@ -32,6 +32,59 @@ public class GithubManager
         return pullRequest?.FirstOrDefault();
     }
 
+    public static Settings SetOwnerRepo(string remoteUrl, string baseRepoPath)
+        => SetOwnerRepo(new(), remoteUrl, baseRepoPath);
+
+    public static Settings SetOwnerRepo(Settings settings, string remoteUrl, string baseRepoPath)
+    {
+        // Extract the owner from the remote URL.
+        if (remoteUrl?.Contains("github.com") == false)
+        {
+            throw new ArgumentException("Malformed URL");
+        }
+
+        string owner;
+        string repo;
+
+        if (remoteUrl.StartsWith("git@github.com"))
+        {
+            // SSH URL
+            var url = remoteUrl.Substring(remoteUrl.IndexOf(":") + 1);
+            url = url.Substring(0, url.LastIndexOf(".git"));
+            var splitUrls = url.Split('/');
+
+            if (splitUrls.Length != 2)
+            {
+                throw new ArgumentException("Malformed URL");
+            }
+
+            owner = splitUrls[0];
+            repo = splitUrls[1];
+        }
+        else
+        {
+            // HTTP URL
+            var url = remoteUrl.Substring(remoteUrl.IndexOf("github.com/") + "github.com/".Length + 1);
+            url = url.Substring(0, url.LastIndexOf(".git"));
+            var splitUrls = url.Split('/');
+
+            if (splitUrls.Length != 2)
+            {
+                throw new ArgumentException("Malformed URL");
+            }
+
+            owner = splitUrls[0];
+            repo = splitUrls[1];
+        }
+
+        settings.GithubOwner = owner;
+        settings.GithubRepo = repo;
+
+        SettingsManager.SaveSettings(settings, baseRepoPath);
+
+        return settings;
+    }
+
     public async Task SetCredentialsAsync(bool forceReLogin = false)
     {
         var token = SettingsManager.GetOauthToken()?.OAuthToken;

--- a/Settings.cs
+++ b/Settings.cs
@@ -13,9 +13,11 @@ public static class SettingsManager
         MissingMemberHandling = MissingMemberHandling.Ignore,
     };
 
+    public static string GetSettingsPath(string baseRepoPath) => Path.Combine(baseRepoPath, _SETTINGS_NAME);
+
     public static Settings GetSettings(string baseRepoPath)
     {
-        var localSettingsPath = Path.Combine(baseRepoPath, _SETTINGS_NAME);
+        var localSettingsPath = GetSettingsPath(baseRepoPath);
 
         // Find the local settings path
         if (!File.Exists(localSettingsPath))
@@ -24,6 +26,14 @@ public static class SettingsManager
         }
 
         return _ReadConfigFile(localSettingsPath);
+    }
+
+    public static void SaveSettings(Settings settings, string baseRepoPath)
+    {
+        var localSettingsPath = GetSettingsPath(baseRepoPath);
+
+        var json = JsonConvert.SerializeObject(settings);
+        File.WriteAllText(localSettingsPath, json);
     }
 
     public static string CreateEmptySettings(string baseRepoPath)
@@ -41,7 +51,7 @@ public static class SettingsManager
             },
             jsonSettings);
 
-        var localSettingsPath = Path.Combine(baseRepoPath, _SETTINGS_NAME);
+        var localSettingsPath = GetSettingsPath(baseRepoPath);
 
         try
         {


### PR DESCRIPTION
This will allow GitPrune to auto-extract the repo owner and repository name into settings file based on the remote. If none is available or it couldn't auto-format, it will revert to the previous behavior of having the user manually enter that info in the config file..

Closes #4 