### PR TITLE
Ensure xdg-utils is installed on Linux machines

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,15 @@ case $platform in
              mkdir -p $directory
         fi
         tar xzf gitprune-linux-x64.tar.gz -C $directory
+
+        # Install browser extention if not installed
+        dpkg -s xdg-utils &> /dev/null
+
+        if [ $? -ne 0 ]; then
+            echo "Installing prerequisites..."
+            sudo apt install -y -qq xdg-utils
+        fi
+
         echo "" >> ~/.profile
         echo "alias gprune=$directory/GitPrune" >> ~/.profile
         source ~/.profile


### PR DESCRIPTION
Issue: `xdg-utils` should come default with Ubuntu machines, but for is not pre-installed on WSL for Windows. This ensures the package is installed and if not, installs it.

Why? `xdg-utils` is used to launch the user's default browser in order to login and get the OAuth token for git. Without it, GitPrune cannot access GitHub and throws a crashing exception.