### PR TITLE
fix: Remove string interpolation issue when using https remote

### DIFF
--- a/GithubManager.cs
+++ b/GithubManager.cs
@@ -64,7 +64,7 @@ public class GithubManager
         else
         {
             // HTTP URL
-            var url = remoteUrl.Substring(remoteUrl.IndexOf("github.com/") + "github.com/".Length + 1);
+            var url = remoteUrl.Substring(remoteUrl.IndexOf("github.com/") + "github.com/".Length);
             url = url.Substring(0, url.LastIndexOf(".git"));
             var splitUrls = url.Split('/');
 


### PR DESCRIPTION
The first character of the owner was being removed when using a `https` remote rather than an `ssh` remote. This fixes the issue.