### PR TITLE
Argument to Reset Config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,19 @@
             "stopAtEntry": false
         },
         {
+            "name": ".NET Core Launch w/ Arguments (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/bin/Debug/net5.0/GitPrune.dll",
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "args": [
+                "--reset"
+            ],
+            "stopAtEntry": false
+        },
+        {
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach",

--- a/Program.cs
+++ b/Program.cs
@@ -21,6 +21,29 @@ if (args.Contains("-v") || args.Contains("--version"))
     return;
 }
 
+// -r or --reset to reset the global config (delete it)
+if (args.Contains("-r") || args.Contains("--reset"))
+{
+    // Ask the user if they wish to reset the config
+    Console.WriteLine("Are you sure you want to clear the global config? You'll have to login again. (y/N)");
+    Console.Write(">> ");
+    var input = Console.ReadLine();
+    if (input.ToLower() == "y")
+    {
+        // Delete the config file
+        try {
+            SettingsManager.DeleteSettingsFile();
+            Console.WriteLine("Config file deleted successfully..");
+            Console.WriteLine();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Error deleting config file: " + e.Message);
+            return;
+        }
+    }
+}
+
 // First check for updates
 try
 {

--- a/Settings.cs
+++ b/Settings.cs
@@ -89,6 +89,23 @@ public static class SettingsManager
         File.WriteAllText(_OAuthTokenConfigPath, json);
     }
 
+    public static void DeleteSettingsFile()
+    {
+        if (File.Exists(_OAuthTokenConfigPath))
+        {
+            File.Delete(_OAuthTokenConfigPath);
+        }
+    }
+
+    public static void DeleteSettingsFile(string baseRepoPath)
+    {
+        var localSettingsPath = GetSettingsPath(baseRepoPath);
+        if (File.Exists(localSettingsPath))
+        {
+            File.Delete(localSettingsPath);
+        }
+    }
+
     static Settings _ReadConfigFile(string configPath)
     {
         try


### PR DESCRIPTION
If the auth token is expired or not working correctly (or you want to switch github accounts for now), we can now clear the global config file using either `-r` or `--reset`.