### PR TITLE
Detect 401 and 403 from getting a PR

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "preLaunchTask": "build",
             "program": "${workspaceFolder}/bin/Debug/net5.0/GitPrune.dll",
             "cwd": "${workspaceFolder}",
-            "console": "internalConsole",
+            "console": "integratedTerminal",
             "stopAtEntry": false
         },
         {

--- a/GithubManager.cs
+++ b/GithubManager.cs
@@ -32,7 +32,11 @@ public class GithubManager
 
             return pullRequest?.FirstOrDefault();
         }
-        catch (Exception ex) when (ex is CredentialsNotSetException || ex is ForbiddenException)
+        catch (Exception ex) when (
+            ex is CredentialsNotSetException
+         || ex is ForbiddenException
+         || ex is NotFoundException
+         || ex is UnauthorizedAccessException)
         {
             Console.WriteLine("There was an issue with your credentials. Please check that you have access to this repo.");
             Console.WriteLine("If you'd like to re-login, start GitPrune with the \"-r\" flag.");


### PR DESCRIPTION
Even with an auth token, a user can sometimes not have access or given access to a repository. This guards against a general exception.

Closes #11 and closes #13 