### PR TITLE
Beta Builds

### DIFF
--- a/GitPrune.csproj
+++ b/GitPrune.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+
+    <DefineConstants Condition=" '$(IsBeta)' == 'true' ">$(DefineConstants);BETA</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Program.cs
+++ b/Program.cs
@@ -17,6 +17,10 @@ var updater = new Updater();
 // -v or --version
 if (args.Contains("-v") || args.Contains("--version"))
 {
+#if BETA
+    Console.WriteLine("BETA VERSION");
+#endif
+
     Console.WriteLine("GitPrune v" + updater.AppVersion.ToString());
     return;
 }

--- a/Updater.cs
+++ b/Updater.cs
@@ -12,7 +12,13 @@ namespace GitPrune
 {
     public class Updater
     {
-        const string _RELEASE_RING = "stable";
+        const string _RELEASE_RING =
+
+#if BETA
+            "stable";
+#else
+            "beta";
+#endif
 
         public Updater()
         {

--- a/publish.bat
+++ b/publish.bat
@@ -8,8 +8,15 @@ IF "%VERSION%" == "" (
   SET VERSION="999.0.0"
 )
 
+IF "%VERSION:~-1%" neq "b" (
+  SET BETA="/p:IsBeta=false"
+) ELSE (
+  SET BETA="/p:IsBeta=true"
+  SET VERSION=%VERSION:~0,-1%
+)
+
 ECHO "Publishing version %VERSION%"
 
-dotnet publish -r win-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
-dotnet publish -r linux-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
-dotnet publish -r osx-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish -r win-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" %BETA% -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish -r linux-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" %BETA% -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish -r osx-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" %BETA% -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true


### PR DESCRIPTION
Allows for builds via beta, using the "beta" update channel.

To build, ensure you use the `publish.bat` script with a version number, and specify a `b` at the end.
Example:

```cmd
publish.bat 1.0.0b
```