### PR TITLE
Store settings file in .git directory

### DIFF
--- a/MigrationHelper.cs
+++ b/MigrationHelper.cs
@@ -1,0 +1,40 @@
+using System.IO;
+static class MigrationHelper {
+
+    // For migrations to 0.2.5, we moved the settings file to the .git directory.
+    // This snippet will migrate the settings file to the new location if it exists
+    // in the main directory. If it also exists in the .git directory but the one
+    // in the .git directory is older, replace it with the one in the main directory.
+    // Then delete the one in the main directory.
+    public static void MoveSettingsFile(string baseRepoDirectory)
+    {
+        try 
+        {
+            var oldPath = Path.Combine(baseRepoDirectory, SettingsManager._SETTINGS_NAME);
+            var newPath = Path.Combine(baseRepoDirectory, ".git", SettingsManager._SETTINGS_NAME);
+
+            var oldFileInfo = new FileInfo(oldPath);
+            var newFileInfo = new FileInfo(newPath);
+
+            if (oldFileInfo.Exists)
+            {
+                // We need to move the file. Check if there is already a settings file in the .git directory
+                if (newFileInfo.Exists && newFileInfo.LastWriteTimeUtc > oldFileInfo.LastWriteTimeUtc)
+                {
+                    // The settings file in the .git directory is newer. Delete the one in the main directory.
+                    oldFileInfo.Delete();
+                }
+                else
+                {
+                    // The settings file in the .git directory is older or doesn't exist. Move the one in the main directory to the .git directory.
+                    newFileInfo.Delete();
+                    oldFileInfo.MoveTo(newPath);
+                }
+            }
+        }
+        catch
+        {
+            // We don't care if the settings file can't be moved - we'll try again on the next migration
+        }
+    }
+}

--- a/Settings.cs
+++ b/Settings.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 public static class SettingsManager
 {
-    const string _SETTINGS_NAME = "prune_config.json";
+    internal const string _SETTINGS_NAME = "prune_config.json";
     static readonly string _OAuthTokenConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), _SETTINGS_NAME);
 
     static readonly JsonSerializerSettings _defaultJsonSettings = new JsonSerializerSettings


### PR DESCRIPTION
We shouldn't put the gitprune oauth token or settings file in the main directory. An update to the LibGit2Sharp changed this in the `repo.Info.Path` to make it the main directory instead of the .git directory.

This changes that back and creates a migration for old repos