### PR TITLE
Fix recursive ordering on chmod

### DIFF
--- a/Updater.cs
+++ b/Updater.cs
@@ -262,7 +262,7 @@ namespace GitPrune
                         CreateNoWindow = true,
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = "/bin/bash",
-                        Arguments = $"-c \"chmod {permissionString} {item} {(recursive ? " -R" : "")}\"",
+                        Arguments = $"-c \"chmod {(recursive ? " -R" : "")} {permissionString} {item}\"",
                     }
                 };
                 process.Start();


### PR DESCRIPTION
On OSX, `chmod`'s `-R` command must be before the permission string and file path, otherwise it will fail. This fixes that.