### PR TITLE
Add Analytics & Crash Reporting

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         path: "Secrets.cs"
         contents: |
-          public class Secrets { public static string ClientId => "${{ secrets.GH_PRUNE_CLIENT_ID }}"; public static string ClientSecret => "${{ secrets.GH_PRUNE_CLIENT_SECRET }}"; public static string AzureBlobTableKey => "${{ secrets.AZ_BLOB_ACCESS_KEY }}"; }
+          public class Secrets { public static string ClientId => "${{ secrets.GH_PRUNE_CLIENT_ID }}"; public static string ClientSecret => "${{ secrets.GH_PRUNE_CLIENT_SECRET }}"; public static string AzureBlobTableKey => "${{ secrets.AZ_BLOB_ACCESS_KEY }}"; public static string AnalyticsInstrumentationKey => "${{ secrets.ANALYTICS_KEY }}"; }
         write-mode: overwrite
         
     - name: Build Windows x64

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         path: "Secrets.cs"
         contents: |
-          public class Secrets { public static string ClientId => "${{ secrets.GH_PRUNE_CLIENT_ID }}"; public static string ClientSecret => "${{ secrets.GH_PRUNE_CLIENT_SECRET }}"; public static string AzureBlobTableKey => "${{ secrets.AZ_BLOB_ACCESS_KEY }}"; }
+          public class Secrets { public static string ClientId => "${{ secrets.GH_PRUNE_CLIENT_ID }}"; public static string ClientSecret => "${{ secrets.GH_PRUNE_CLIENT_SECRET }}"; public static string AzureBlobTableKey => "${{ secrets.AZ_BLOB_ACCESS_KEY }}"; public static string AnalyticsInstrumentationKey => "${{ secrets.ANALYTICS_KEY }}"; }
         write-mode: overwrite
         
     - name: Build Windows x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         path: "Secrets.cs"
         contents: |
-          public class Secrets { public static string ClientId => "${{ secrets.GH_PRUNE_CLIENT_ID }}"; public static string ClientSecret => "${{ secrets.GH_PRUNE_CLIENT_SECRET }}"; public static string AzureBlobTableKey => "${{ secrets.AZ_BLOB_ACCESS_KEY }}"; }
+          public class Secrets { public static string ClientId => "${{ secrets.GH_PRUNE_CLIENT_ID }}"; public static string ClientSecret => "${{ secrets.GH_PRUNE_CLIENT_SECRET }}"; public static string AzureBlobTableKey => "${{ secrets.AZ_BLOB_ACCESS_KEY }}"; public static string AnalyticsInstrumentationKey => "${{ secrets.ANALYTICS_KEY }}"; }
         write-mode: overwrite
         
     - name: Build Windows x64

--- a/AnalyticHelper.cs
+++ b/AnalyticHelper.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+public class AnalyticHelper
+{
+    public static class Keys {
+        public const string DELETABLE_BRANCHES = "deletable_branches";
+        public const string DELETE_BRANCH = "delete_branch";
+        public const string UPDATE_AVAILABLE = "update_available";
+        public const string UPDATE_APP = "update_app";
+        public const string CHECK_VERSION = "check_version";
+        public const string RESET_CONFIG = "reset_config";
+        public const string USE_GITPRUNE = "use_gitprune";
+    }
+
+    private TelemetryClient _telemetryClient;
+    private string _appVersion;
+    private string _appReleaseRing;
+
+    public AnalyticHelper(string appVersion, string appReleaseRing)
+    {
+        _appVersion = appVersion;
+        _appReleaseRing = appReleaseRing;
+
+        // Setup the analytics tracker
+        var config = TelemetryConfiguration.CreateDefault();
+        config.InstrumentationKey = Secrets.AnalyticsInstrumentationKey;
+        _telemetryClient = new TelemetryClient(config);
+        _telemetryClient.Context.Device.OperatingSystem = Environment.OSVersion.ToString();
+        _telemetryClient.Context.GlobalProperties.Add("app_version", _appVersion);
+        _telemetryClient.Context.GlobalProperties.Add("app_release_ring", _appReleaseRing);
+    }
+
+    #region Analytic Events
+
+    public void TrackDeletableBranches(int count) => _TrackEvent(Keys.DELETABLE_BRANCHES, new Dictionary<string, string> { { "count", count.ToString() } });
+
+    public void TrackDeleteBranch() => _TrackEvent(Keys.DELETE_BRANCH);
+
+    public void TrackUpdateApp(string oldVersion, string newVersion) => _TrackEvent(Keys.UPDATE_APP, new Dictionary<string, string> { { "old_version", oldVersion }, { "new_version", newVersion } });
+
+    public void TrackUpdateAvailable(bool choseToUpdate) => _TrackEvent(Keys.UPDATE_AVAILABLE, new Dictionary<string, string> { { "chose_to_update", choseToUpdate.ToString() } });
+
+    public void TrackCheckVersion() => _TrackEvent(Keys.CHECK_VERSION);
+
+    public void TrackResetConfig() => _TrackEvent(Keys.RESET_CONFIG);
+
+    public void TrackUseGitPrune() => _TrackEvent(Keys.USE_GITPRUNE);
+
+    #endregion
+
+    public void TrackException(Exception ex)
+    {
+        try
+        {
+            _telemetryClient.TrackException(ex);
+        } catch { } // If we can't send a tracked exception, no point in trying to send another one
+    }
+
+    public void Flush() 
+    {
+        _telemetryClient.Flush();
+        // Give 200ms for the flush to complete
+        System.Threading.Thread.Sleep(800);
+    }
+
+    void _TrackEvent(string key, Dictionary<string, string> properties = null)
+    {
+        try
+        {
+            var telemetry = new EventTelemetry(key);
+
+            // Add custom properties if they exist
+            if (properties != null)
+            {
+                foreach (var property in properties)
+                {
+                    telemetry.Properties.Add(property.Key, property.Value);
+                }
+            }
+
+            // Send the analytics
+            _telemetryClient.TrackEvent(telemetry);
+        }
+        catch (Exception ex) {
+            // Try to send exception analytic
+            _telemetryClient.TrackException(ex);
+        }
+    }
+}

--- a/GitPrune.csproj
+++ b/GitPrune.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.2.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0096" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Common" Version="11.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/ISecrets.cs
+++ b/ISecrets.cs
@@ -11,4 +11,6 @@ public interface ISecrets
     static string ClientSecret { get; }
 
     static string AzureBlobTableKey { get; }
+
+    static string AnalyticsInstrumentationKey { get; }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -12,6 +12,9 @@ const int _BULK_GITHUB_REQUESTS = 5;
 string[] _BRANCHES_TO_EXCLUDE = new string[] { "master", "main", "dev", "development" };
 
 var updater = new Updater();
+var analytics = new AnalyticHelper(updater.AppVersion.ToString(), Updater.RELEASE_RING);
+
+analytics.TrackUseGitPrune();
 
 // Get specific args
 // -v or --version
@@ -22,6 +25,8 @@ if (args.Contains("-v") || args.Contains("--version"))
 #endif
 
     Console.WriteLine("GitPrune v" + updater.AppVersion.ToString());
+    analytics.TrackCheckVersion();
+    analytics.Flush();
     return;
 }
 
@@ -39,10 +44,13 @@ if (args.Contains("-r") || args.Contains("--reset"))
             SettingsManager.DeleteSettingsFile();
             Console.WriteLine("Config file deleted successfully..");
             Console.WriteLine();
+            analytics.TrackResetConfig();
         }
         catch (Exception e)
         {
             Console.WriteLine("Error deleting config file: " + e.Message);
+            analytics.TrackException(e);
+            analytics.Flush();
             return;
         }
     }
@@ -61,12 +69,18 @@ try
         {
             Console.WriteLine();
             Console.WriteLine("Updating... Please wait");
+            analytics.TrackUpdateAvailable(true);
             updater.Update();
+        }
+        else
+        {
+            analytics.TrackUpdateAvailable(false);
         }
     }
 }
 catch (Exception ex) {
     Console.WriteLine("Error while checking for or completing the update! " + ex.ToString());
+    analytics.Flush();
     return;
 }
 
@@ -81,6 +95,7 @@ Console.WriteLine("Finding Branches to Prune...");
 
 if (!Repository.IsValid(workingDirectory)) {
     Console.WriteLine("You are not in a git directory.");
+    analytics.Flush();
     return;
 }
 
@@ -125,6 +140,7 @@ if (settings == null
             Console.WriteLine($"Local settings file created: {settingsPath}");
 
         Console.WriteLine("Please open your settings file and fill out the settings before running git prune.");
+        analytics.Flush();
         return;
     }
 }
@@ -139,6 +155,7 @@ catch (Exception ex)
 {
     Console.WriteLine("Unfortunately an error occured. Please try again.");
     Console.WriteLine($"Error: {ex.Message}");
+    analytics.Flush();
     return;
 }
 
@@ -169,9 +186,12 @@ WriteProgress($"\rProgress: {localBranches.Length}/{localBranches.Length}");
 Console.WriteLine();
 Console.WriteLine("Done.");
 
+analytics.TrackDeletableBranches(branchesToDelete.Count);
+
 if (branchesToDelete.Count == 0)
 {
     Console.WriteLine("You have no local branches associated with a merged PR. Congrats!");
+    analytics.Flush();
     return;
 }
 
@@ -197,21 +217,28 @@ if (isCommitting)
         if (localBranches.Any(b => b.FriendlyName == repo.Head.FriendlyName))
         {
             Console.WriteLine("You are currently on one of the branches to delete. Please switch to another branch and run Git Prune again.");
+            analytics.Flush();
             return;
         }
         
         try
         {
             foreach(var branch in branchesToDelete)
+            {
                 repo.Branches.Remove(branch);
+                analytics.TrackDeleteBranch();
+            }
 
             Console.WriteLine($"Deleted {branchesToDelete.Count()} branches.");
         }
         catch (Exception ex)
         {
             Console.WriteLine($"An error occured while deleting branches: {ex.Message}");
+            analytics.TrackException(ex);
         }
     }
+
+    analytics.Flush();
 }
 
 void WriteProgress(string message)

--- a/Updater.cs
+++ b/Updater.cs
@@ -12,7 +12,7 @@ namespace GitPrune
 {
     public class Updater
     {
-        const string _RELEASE_RING =
+        public const string RELEASE_RING =
 
 #if BETA
             "beta";
@@ -119,7 +119,7 @@ namespace GitPrune
 
         public bool UpdateAvailable()
         {
-            var result = _tableClient.Query<TableEntity>(e => e.PartitionKey == "version" && e.RowKey == _RELEASE_RING);
+            var result = _tableClient.Query<TableEntity>(e => e.PartitionKey == "version" && e.RowKey == RELEASE_RING);
 
             var versionResult = result.FirstOrDefault();
             if (versionResult == null) { throw new Exception("Could not query update table."); }


### PR DESCRIPTION
This adds analytics and crash reporting to the app:

## Crash Reporting
Manually-caught exceptions in the main program will be caught and sent. I'm unsure about uncaught exceptions throughout the app

## Analytics
The following events and keys are being reported:

### Always-reported keys:
 - Device OS
 - Device Type
 - App Version
 - Release Ring (beta or stable)

### Events and properties:
 - User starts GitPrune
 - User checks the versino
 - User resets the config
 - There is an update available - check if user chooses to update or not
 - Checked for branches to delete - property is a int for the number of deletable branches
 - Tracks when a branch is deleted. No properties, just getting a count.

Note: _No identifiable info or information about the repo is sent to the analytics_