### PR TITLE
Fix branch deletion to continue after individual failures

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,20 +12,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Set Build Environment
-      uses: DamianReeves/write-file-action@v1.0
-      with:
-        path: "Secrets.cs"
-        contents: |
+      run: |
+        cat <<'EOF' > Secrets.cs
           public class Secrets { public static string ClientId => "${{ secrets.GH_PRUNE_CLIENT_ID }}"; public static string ClientSecret => "${{ secrets.GH_PRUNE_CLIENT_SECRET }}"; public static string AzureBlobTableKey => "${{ secrets.AZ_BLOB_ACCESS_KEY }}"; public static string AnalyticsInstrumentationConnectionString => "${{ secrets.ANALYTICS_CONNECTION_STRING }}"; }
-        write-mode: overwrite
+        EOF
         
     - name: Build Windows x64
       run: dotnet publish -r win-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
@@ -35,19 +33,19 @@ jobs:
       run: dotnet publish -r osx-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
       
     - name: Upload Windows Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Win-Compiled-Packages
         path: |
           bin/Release/net8.0/win-x64/publish
     - name: Upload Linux Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Linux-Compiled-Packages
         path: |
           bin/Release/net8.0/linux-x64/publish
     - name: Upload OSX Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: OSX-Compiled-Packages
         path: |

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -11,23 +11,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/b}
+      run: echo "VERSION=${GITHUB_REF#refs/tags/b}" >> "$GITHUB_OUTPUT"
     - name: Restore dependencies
       run: dotnet restore
     - name: Set Build Environment
-      uses: DamianReeves/write-file-action@v1.0
-      with:
-        path: "Secrets.cs"
-        contents: |
+      run: |
+        cat <<'EOF' > Secrets.cs
           public class Secrets { public static string ClientId => "${{ secrets.GH_PRUNE_CLIENT_ID }}"; public static string ClientSecret => "${{ secrets.GH_PRUNE_CLIENT_SECRET }}"; public static string AzureBlobTableKey => "${{ secrets.AZ_BLOB_ACCESS_KEY }}"; public static string AnalyticsInstrumentationConnectionString => "${{ secrets.ANALYTICS_CONNECTION_STRING }}"; }
-        write-mode: overwrite
+        EOF
         
     - name: Build Windows x64
       run: dotnet publish -r win-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="${{ steps.get_version.outputs.VERSION }}" /p:IsBeta=true -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
@@ -48,7 +46,7 @@ jobs:
         tar -czf publish_files/gitprune-osx-x64.tar.gz -C bin/Release/net8.0/osx-x64/publish .
 
     - name: Upload Releases
-      uses: bacongobbler/azure-blob-storage-upload@v1.2.0
+      uses: bacongobbler/azure-blob-storage-upload@v3
       with:
         source_dir: 'publish_files'
         container_name: 'git-prune-beta'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,29 +5,30 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
     - name: Restore dependencies
       run: dotnet restore
     - name: Set Build Environment
-      uses: DamianReeves/write-file-action@v1.0
-      with:
-        path: "Secrets.cs"
-        contents: |
+      run: |
+        cat <<'EOF' > Secrets.cs
           public class Secrets { public static string ClientId => "${{ secrets.GH_PRUNE_CLIENT_ID }}"; public static string ClientSecret => "${{ secrets.GH_PRUNE_CLIENT_SECRET }}"; public static string AzureBlobTableKey => "${{ secrets.AZ_BLOB_ACCESS_KEY }}"; public static string AnalyticsInstrumentationConnectionString => "${{ secrets.ANALYTICS_CONNECTION_STRING }}"; }
-        write-mode: overwrite
+        EOF
         
     - name: Build Windows x64
       run: dotnet publish -r win-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="${{ steps.get_version.outputs.VERSION }}" -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
@@ -48,7 +49,7 @@ jobs:
         tar -czf publish_files/gitprune-osx-x64.tar.gz -C bin/Release/net8.0/osx-x64/publish .
 
     - name: Upload Releases
-      uses: bacongobbler/azure-blob-storage-upload@v1.2.0
+      uses: bacongobbler/azure-blob-storage-upload@v3
       with:
         source_dir: 'publish_files'
         container_name: 'git-prune'
@@ -68,7 +69,7 @@ jobs:
         connection_string: "${{ secrets.ACURETABLECONNECTIONSTRING }}"
 
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         fail_on_unmatched_files: true
         files: |

--- a/Program.cs
+++ b/Program.cs
@@ -243,21 +243,40 @@ if (isCommitting)
             analytics.Flush();
             return;
         }
-        
-        try
+
+        var deletedBranches = new List<string>();
+        var failedBranches = new List<(string Name, string Error)>();
+
+        foreach (var branch in branchesToDelete)
         {
-            foreach(var branch in branchesToDelete)
+            try
             {
                 repo.Branches.Remove(branch);
                 analytics.TrackDeleteBranch();
+                deletedBranches.Add(branch.FriendlyName);
             }
-
-            Console.WriteLine($"Deleted {branchesToDelete.Count()} branches.");
+            catch (Exception ex)
+            {
+                failedBranches.Add((branch.FriendlyName, ex.Message));
+                analytics.TrackException(ex);
+            }
         }
-        catch (Exception ex)
+
+        Console.WriteLine();
+        Console.WriteLine($"Deleted {deletedBranches.Count} branch{(deletedBranches.Count == 1 ? string.Empty : "es")}.");
+
+        if (deletedBranches.Count > 0)
         {
-            Console.WriteLine($"An error occured while deleting branches: {ex.Message}");
-            analytics.TrackException(ex);
+            Console.WriteLine("Successfully deleted:");
+            foreach (var branchName in deletedBranches)
+                Console.WriteLine($"\t- {branchName}");
+        }
+
+        if (failedBranches.Count > 0)
+        {
+            Console.WriteLine("Failed to delete:");
+            foreach (var failedBranch in failedBranches)
+                Console.WriteLine($"\t- {failedBranch.Name}: {failedBranch.Error}");
         }
     }
 


### PR DESCRIPTION
## Summary
- Change branch cleanup so one failed deletion does not stop later branches from being processed
- Track deleted branches and failed branches separately during the delete pass
- Show a clearer end-of-run summary with both successful deletions and per-branch failure messages

## Testing
- `dotnet build .\GitPrune.sln`