### PR TITLE
feat: prune merged worktrees

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,19 +22,24 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies
-      run: dotnet restore
+      run: |
+        dotnet restore GitPrune.csproj
+        dotnet restore GitPrune.Tests/GitPrune.Tests.csproj
     - name: Set Build Environment
       run: |
         cat <<'EOF' > Secrets.cs
           public class Secrets { public static string ClientId => "${{ secrets.GH_PRUNE_CLIENT_ID }}"; public static string ClientSecret => "${{ secrets.GH_PRUNE_CLIENT_SECRET }}"; public static string AzureBlobTableKey => "${{ secrets.AZ_BLOB_ACCESS_KEY }}"; public static string AnalyticsInstrumentationConnectionString => "${{ secrets.ANALYTICS_CONNECTION_STRING }}"; }
         EOF
+
+    - name: Test
+      run: dotnet test GitPrune.Tests/GitPrune.Tests.csproj --no-restore
         
     - name: Build Windows x64
-      run: dotnet publish -r win-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+      run: dotnet publish GitPrune.csproj -r win-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
     - name: Build Linux x64
-      run: dotnet publish -r linux-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+      run: dotnet publish GitPrune.csproj -r linux-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
     - name: Build OSX x64
-      run: dotnet publish -r osx-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+      run: dotnet publish GitPrune.csproj -r osx-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
       
     - name: Upload Windows Artifacts
       uses: actions/upload-artifact@v6

--- a/AnalyticHelper.cs
+++ b/AnalyticHelper.cs
@@ -9,6 +9,8 @@ public class AnalyticHelper
     public static class Keys {
         public const string DELETABLE_BRANCHES = "deletable_branches";
         public const string DELETE_BRANCH = "delete_branch";
+        public const string DELETABLE_WORKTREES = "deletable_worktrees";
+        public const string DELETE_WORKTREE = "delete_worktree";
         public const string UPDATE_AVAILABLE = "update_available";
         public const string UPDATE_APP = "update_app";
         public const string CHECK_VERSION = "check_version";
@@ -39,6 +41,10 @@ public class AnalyticHelper
     public void TrackDeletableBranches(int count) => _TrackEvent(Keys.DELETABLE_BRANCHES, new Dictionary<string, string> { { "count", count.ToString() } });
 
     public void TrackDeleteBranch() => _TrackEvent(Keys.DELETE_BRANCH);
+
+    public void TrackDeletableWorktrees(int count) => _TrackEvent(Keys.DELETABLE_WORKTREES, new Dictionary<string, string> { { "count", count.ToString() } });
+
+    public void TrackDeleteWorktree() => _TrackEvent(Keys.DELETE_WORKTREE);
 
     public void TrackUpdateAvailable(bool choseToUpdate) => _TrackEvent(Keys.UPDATE_AVAILABLE, new Dictionary<string, string> { { "chose_to_update", choseToUpdate.ToString() } });
 

--- a/GitPrune.Tests/GitPrune.Tests.csproj
+++ b/GitPrune.Tests/GitPrune.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../GitPrune.csproj" />
+  </ItemGroup>
+</Project>

--- a/GitPrune.Tests/GitWorktreeManagerTests.cs
+++ b/GitPrune.Tests/GitWorktreeManagerTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+public class GitWorktreeManagerTests
+{
+    [Fact]
+    public void ParseWorktreeList_ParsesBranchWorktreesAndDetachedWorktrees()
+    {
+        const string output = """
+            worktree /repos/project
+            HEAD aaaaaaa
+            branch refs/heads/main
+
+            worktree /repos/project-feature
+            HEAD bbbbbbb
+            branch refs/heads/feature/worktrees
+
+            worktree /repos/project-detached
+            HEAD ccccccc
+            detached
+
+            """;
+
+        var worktrees = GitWorktreeManager.ParseWorktreeList(output);
+
+        Assert.Collection(
+            worktrees,
+            main =>
+            {
+                Assert.True(main.IsMain);
+                Assert.Equal("/repos/project", main.Path);
+                Assert.Equal("main", main.BranchName);
+            },
+            feature =>
+            {
+                Assert.False(feature.IsMain);
+                Assert.Equal("feature/worktrees", feature.BranchName);
+            },
+            detached => Assert.Null(detached.BranchName));
+    }
+
+    [Fact]
+    public void Remove_RequiresForceForAnUntrackedFileThenRemovesTheWorktree()
+    {
+        var repositoryPath = Path.Combine(Path.GetTempPath(), $"GitPruneTests-{Guid.NewGuid():N}");
+        var worktreePath = Path.Combine(repositoryPath, "feature-worktree");
+
+        try
+        {
+            Directory.CreateDirectory(repositoryPath);
+            RunGit(repositoryPath, "init");
+            RunGit(repositoryPath, "config", "user.email", "tests@example.com");
+            RunGit(repositoryPath, "config", "user.name", "GitPrune Tests");
+            File.WriteAllText(Path.Combine(repositoryPath, "README.md"), "test repository");
+            RunGit(repositoryPath, "add", "README.md");
+            RunGit(repositoryPath, "commit", "-m", "Initial commit");
+            RunGit(repositoryPath, "worktree", "add", "-b", "feature/worktree-prune", worktreePath);
+            File.WriteAllText(Path.Combine(worktreePath, "untracked.txt"), "requires force");
+
+            var regularRemoval = GitWorktreeManager.Remove(repositoryPath, worktreePath, force: false);
+            var forcedRemoval = GitWorktreeManager.Remove(repositoryPath, worktreePath, force: true);
+
+            Assert.False(regularRemoval.Succeeded);
+            Assert.True(forcedRemoval.Succeeded, forcedRemoval.Error);
+            Assert.False(Directory.Exists(worktreePath));
+        }
+        finally
+        {
+            if (Directory.Exists(repositoryPath))
+            {
+                Directory.Delete(repositoryPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void DeleteBranch_ForceDeletesABranchThatIsNotGitMerged()
+    {
+        var repositoryPath = Path.Combine(Path.GetTempPath(), $"GitPruneTests-{Guid.NewGuid():N}");
+
+        try
+        {
+            Directory.CreateDirectory(repositoryPath);
+            RunGit(repositoryPath, "init");
+            RunGit(repositoryPath, "config", "user.email", "tests@example.com");
+            RunGit(repositoryPath, "config", "user.name", "GitPrune Tests");
+            File.WriteAllText(Path.Combine(repositoryPath, "README.md"), "test repository");
+            RunGit(repositoryPath, "add", "README.md");
+            RunGit(repositoryPath, "commit", "-m", "Initial commit");
+            RunGit(repositoryPath, "branch", "squash-merged-feature");
+
+            var result = GitWorktreeManager.DeleteBranch(repositoryPath, "squash-merged-feature");
+
+            Assert.True(result.Succeeded, result.Error);
+            Assert.False(BranchExists(repositoryPath, "squash-merged-feature"));
+        }
+        finally
+        {
+            if (Directory.Exists(repositoryPath))
+            {
+                Directory.Delete(repositoryPath, recursive: true);
+            }
+        }
+    }
+
+    static void RunGit(string workingDirectory, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo);
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, process.StandardError.ReadToEnd());
+    }
+
+    static bool BranchExists(string workingDirectory, string branchName)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("show-ref");
+        startInfo.ArgumentList.Add("--verify");
+        startInfo.ArgumentList.Add($"refs/heads/{branchName}");
+
+        using var process = Process.Start(startInfo);
+        process.WaitForExit();
+        return process.ExitCode == 0;
+    }
+}

--- a/GitPrune.csproj
+++ b/GitPrune.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="GitPrune.Tests/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/GitWorktreeManager.cs
+++ b/GitWorktreeManager.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+public sealed class GitWorktree
+{
+    public GitWorktree(string path, string branchName, bool isMain)
+    {
+        Path = path;
+        BranchName = branchName;
+        IsMain = isMain;
+    }
+
+    public string Path { get; }
+    public string BranchName { get; }
+    public bool IsMain { get; }
+}
+
+public sealed class GitCommandResult
+{
+    public GitCommandResult(int exitCode, string output, string error)
+    {
+        ExitCode = exitCode;
+        Output = output;
+        Error = error;
+    }
+
+    public int ExitCode { get; }
+    public string Output { get; }
+    public string Error { get; }
+    public bool Succeeded => ExitCode == 0;
+}
+
+public static class GitWorktreeManager
+{
+    const string _BRANCH_PREFIX = "refs/heads/";
+
+    public static IReadOnlyList<GitWorktree> List(string workingDirectory)
+    {
+        var result = Run(workingDirectory, "worktree", "list", "--porcelain");
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException($"Unable to list git worktrees: {GetError(result)}");
+        }
+
+        return ParseWorktreeList(result.Output);
+    }
+
+    public static IReadOnlyList<GitWorktree> ParseWorktreeList(string output)
+    {
+        var worktrees = new List<GitWorktree>();
+        string path = null;
+        string branchName = null;
+
+        void AddWorktree()
+        {
+            if (string.IsNullOrWhiteSpace(path)) return;
+
+            worktrees.Add(new GitWorktree(path, branchName, worktrees.Count == 0));
+            path = null;
+            branchName = null;
+        }
+
+        foreach (var line in (output ?? string.Empty).Replace("\r\n", "\n").Split('\n'))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                AddWorktree();
+                continue;
+            }
+
+            if (line.StartsWith("worktree ", StringComparison.Ordinal))
+            {
+                AddWorktree();
+                path = line["worktree ".Length..];
+                continue;
+            }
+
+            if (line.StartsWith("branch ", StringComparison.Ordinal))
+            {
+                var branch = line["branch ".Length..];
+                branchName = branch.StartsWith(_BRANCH_PREFIX, StringComparison.Ordinal)
+                    ? branch[_BRANCH_PREFIX.Length..]
+                    : branch;
+            }
+        }
+
+        AddWorktree();
+        return worktrees;
+    }
+
+    public static string GetCommonGitDirectory(string workingDirectory)
+    {
+        var result = Run(workingDirectory, "rev-parse", "--git-common-dir");
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException($"Unable to find the common git directory: {GetError(result)}");
+        }
+
+        return ToAbsolutePath(workingDirectory, result.Output.Trim());
+    }
+
+    public static string GetCurrentWorktreePath(string workingDirectory)
+    {
+        var result = Run(workingDirectory, "rev-parse", "--show-toplevel");
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException($"Unable to find the current worktree: {GetError(result)}");
+        }
+
+        return ToAbsolutePath(workingDirectory, result.Output.Trim());
+    }
+
+    public static GitCommandResult Remove(string workingDirectory, string worktreePath, bool force)
+    {
+        return force
+            ? Run(workingDirectory, "worktree", "remove", "-f", worktreePath)
+            : Run(workingDirectory, "worktree", "remove", worktreePath);
+    }
+
+    public static GitCommandResult DeleteBranch(string workingDirectory, string branchName)
+    {
+        // GitHub confirmation makes a forced local delete safe even for squash-merged branches.
+        return Run(workingDirectory, "branch", "-D", "--", branchName);
+    }
+
+    public static bool PathsEqual(string firstPath, string secondPath)
+    {
+        if (string.IsNullOrWhiteSpace(firstPath) || string.IsNullOrWhiteSpace(secondPath)) return false;
+
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        return string.Equals(
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(firstPath)),
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(secondPath)),
+            comparison);
+    }
+
+    static GitCommandResult Run(string workingDirectory, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Unable to start git.");
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        return new GitCommandResult(process.ExitCode, output, error);
+    }
+
+    static string ToAbsolutePath(string workingDirectory, string path)
+    {
+        return Path.IsPathRooted(path)
+            ? Path.GetFullPath(path)
+            : Path.GetFullPath(Path.Combine(workingDirectory, path));
+    }
+
+    static string GetError(GitCommandResult result)
+    {
+        return string.IsNullOrWhiteSpace(result.Error) ? result.Output.Trim() : result.Error.Trim();
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -128,11 +128,8 @@ using var repo = new Repository(workingDirectory);
 // Migrate the settings file if it exists in the main directory
 MigrationHelper.DeleteSettingsFile(workingDirectory);
 
-// The gitDirectory is the directory where the .git folder is located for the settings
-var gitDirectory = repo.Info.Path;
-if (!gitDirectory.EndsWith(".git") &&  Directory.Exists(Path.Combine(gitDirectory, ".git"))) {
-    gitDirectory = Path.Combine(gitDirectory, ".git");
-}
+// Every worktree shares this directory, so the repository configuration stays consistent.
+var gitDirectory = GitWorktreeManager.GetCommonGitDirectory(workingDirectory);
 
 // Check the config
 var repoRemote = repo.Network.Remotes.FirstOrDefault();
@@ -186,102 +183,191 @@ var localBranches = repo.Branches
     .Where(b => !b.IsRemote && !_BRANCHES_TO_EXCLUDE.Contains(b.FriendlyName))
     .ToArray();
 
-var branchesToDelete = new List<Branch>();
-
-Console.WriteLine($"Found {localBranches.Length} local branches.");
-Console.WriteLine($"Determining which branches have been merged. Please wait... (this may take a minute)");
-
-for (int i = 0; i < localBranches.Length; i += _BULK_GITHUB_REQUESTS) 
+var worktrees = Array.Empty<GitWorktree>();
+var currentWorktreePath = string.Empty;
+try
 {
-    WriteProgress($"\rProgress: {i}/{localBranches.Length}");
+    worktrees = GitWorktreeManager.List(workingDirectory).ToArray();
+    currentWorktreePath = GitWorktreeManager.GetCurrentWorktreePath(workingDirectory);
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Unable to inspect worktrees. Only ordinary branch pruning will be available. Error: {ex.Message}");
+    analytics.TrackException(ex);
+}
+
+bool IsProtectedWorktree(GitWorktree worktree)
+    => worktree.IsMain || GitWorktreeManager.PathsEqual(worktree.Path, currentWorktreePath);
+
+var protectedBranchNames = new HashSet<string>(
+    worktrees
+        .Where(IsProtectedWorktree)
+        .Where(w => !string.IsNullOrWhiteSpace(w.BranchName))
+        .Select(w => w.BranchName),
+    StringComparer.Ordinal);
+
+// Never delete the checked-out branch, even when worktree discovery was unavailable.
+if (repo.Head?.FriendlyName != null)
+{
+    protectedBranchNames.Add(repo.Head.FriendlyName);
+}
+
+var worktreesByBranch = worktrees
+    .Where(w => !IsProtectedWorktree(w) && !string.IsNullOrWhiteSpace(w.BranchName))
+    .GroupBy(w => w.BranchName, StringComparer.Ordinal)
+    .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+var branchesToEvaluate = localBranches
+    .Where(b => !protectedBranchNames.Contains(b.FriendlyName))
+    .ToArray();
+var mergedBranchNames = new HashSet<string>(StringComparer.Ordinal);
+
+Console.WriteLine($"Found {localBranches.Length} local branches and {worktrees.Length} worktrees.");
+Console.WriteLine("Determining which branches have been merged. Please wait... (this may take a minute)");
+
+for (int i = 0; i < branchesToEvaluate.Length; i += _BULK_GITHUB_REQUESTS)
+{
+    WriteProgress($"\rProgress: {i}/{branchesToEvaluate.Length}");
 
     var lowIndex = i;
-    var highIndex = Math.Min(i + _BULK_GITHUB_REQUESTS, localBranches.Length);
-
-    var tasks = localBranches[lowIndex..highIndex]
+    var highIndex = Math.Min(i + _BULK_GITHUB_REQUESTS, branchesToEvaluate.Length);
+    var tasks = branchesToEvaluate[lowIndex..highIndex]
         .Select(async b => (LocalBranch: b, PullRequest: await _githubManager.FindClosedPullRequestFromBranchName(b.FriendlyName)));
 
     var results = await Task.WhenAll(tasks).ConfigureAwait(false);
-    branchesToDelete.AddRange(results.Where(r => r.PullRequest?.Merged ?? false).Select(r => r.LocalBranch));
+    foreach (var result in results.Where(r => r.PullRequest?.Merged ?? false))
+    {
+        mergedBranchNames.Add(result.LocalBranch.FriendlyName);
+    }
 }
 
-WriteProgress($"\rProgress: {localBranches.Length}/{localBranches.Length}");
+WriteProgress($"\rProgress: {branchesToEvaluate.Length}/{branchesToEvaluate.Length}");
 Console.WriteLine();
 Console.WriteLine("Done.");
 
-analytics.TrackDeletableBranches(branchesToDelete.Count);
+var pruneTargets = localBranches
+    .Where(b => !protectedBranchNames.Contains(b.FriendlyName) && mergedBranchNames.Contains(b.FriendlyName))
+    .Select(b => new PrunableTarget(
+        b,
+        worktreesByBranch.TryGetValue(b.FriendlyName, out var worktree) ? worktree : null))
+    .ToArray();
 
-if (branchesToDelete.Count == 0)
+var worktreeTargetCount = pruneTargets.Count(target => target.Worktree != null);
+analytics.TrackDeletableBranches(pruneTargets.Length);
+analytics.TrackDeletableWorktrees(worktreeTargetCount);
+
+if (pruneTargets.Length == 0)
 {
-    Console.WriteLine("You have no local branches associated with a merged PR. Congrats!");
+    Console.WriteLine("You have no local branches or worktrees associated with a merged PR. Congrats!");
     analytics.Flush();
     return;
 }
 
-Console.WriteLine("Branches that will be deleted:");
-foreach (var branch in branchesToDelete)
-    Console.WriteLine($"\t- {branch.FriendlyName}");
+Console.WriteLine("Branches and worktrees associated with merged PRs:");
+foreach (var target in pruneTargets)
+{
+    var worktreeLabel = target.Worktree == null ? string.Empty : $" (worktree: {target.Worktree.Path})";
+    Console.WriteLine($"\t- {target.Branch.FriendlyName}{worktreeLabel}");
+}
 
 if (isCommitting)
 {
     Console.WriteLine();
-    Console.WriteLine(
-        branchesToDelete.Count switch {
-            1 => $"Do you wish to delete this branch from your local Git?",
-            _ => "Do you wish to delete these branches from your local Git?"
-        }
-    );
+    Console.WriteLine("Choose what to delete:");
+    Console.WriteLine("\t[a] All listed branches and worktrees");
+    Console.WriteLine("\t[w] Worktrees only (keep their local branches)");
+    Console.WriteLine("\t[b] Branches only in this worktree (skip linked worktrees)");
+    Console.Write("a/w/b (default: cancel) >");
 
-    Console.Write("y/N >");
-    var result = Console.ReadLine().ToLower().Trim();
-    if (result == "y" || result == "yes")
+    var selection = ParsePruneSelection(Console.ReadLine());
+    if (selection == PruneSelection.None)
     {
-        // Check if we are currently in one of the branches to delete
-        if (branchesToDelete.Any(b => b.FriendlyName == repo.Head.FriendlyName))
-        {
-            Console.WriteLine("You are currently on one of the branches to delete. Please switch to another branch and run Git Prune again.");
-            analytics.Flush();
-            return;
-        }
-
+        Console.WriteLine("No branches or worktrees were deleted.");
+    }
+    else
+    {
         var deletedBranches = new List<string>();
         var failedBranches = new List<(string Name, string Error)>();
+        var deletedWorktrees = new List<string>();
+        var failedWorktrees = new List<(string Path, string Error)>();
+        var branchTargetsToDelete = new List<PrunableTarget>();
 
-        foreach (var branch in branchesToDelete)
+        if (selection is PruneSelection.All or PruneSelection.WorktreesOnly)
+        {
+            foreach (var target in pruneTargets.Where(target => target.Worktree != null))
+            {
+                if (TryRemoveWorktree(target.Worktree, deletedWorktrees, failedWorktrees)
+                    && selection == PruneSelection.All)
+                {
+                    branchTargetsToDelete.Add(target);
+                }
+            }
+        }
+
+        if (selection is PruneSelection.All or PruneSelection.BranchesOnly)
+        {
+            branchTargetsToDelete.AddRange(pruneTargets.Where(target => target.Worktree == null));
+        }
+
+        foreach (var target in branchTargetsToDelete)
         {
             try
             {
-                repo.Branches.Remove(branch);
-                analytics.TrackDeleteBranch();
-                deletedBranches.Add(branch.FriendlyName);
+                var result = GitWorktreeManager.DeleteBranch(workingDirectory, target.Branch.FriendlyName);
+                if (result.Succeeded)
+                {
+                    analytics.TrackDeleteBranch();
+                    deletedBranches.Add(target.Branch.FriendlyName);
+                }
+                else
+                {
+                    var error = DescribeBranchDeleteFailure(target.Branch.FriendlyName, result);
+                    failedBranches.Add((target.Branch.FriendlyName, error));
+                    analytics.TrackException(new InvalidOperationException(error));
+                }
             }
             catch (Exception ex)
             {
-                failedBranches.Add((branch.FriendlyName, ex.Message));
+                var error = $"Unable to start `git branch -D -- {target.Branch.FriendlyName}`: {ex.Message}";
+                failedBranches.Add((target.Branch.FriendlyName, error));
                 analytics.TrackException(ex);
             }
         }
 
         Console.WriteLine();
-        Console.WriteLine($"Deleted {deletedBranches.Count} branch{(deletedBranches.Count == 1 ? string.Empty : "es")}.");
+        Console.WriteLine($"Deleted {deletedBranches.Count} branch{(deletedBranches.Count == 1 ? string.Empty : "es")} and {deletedWorktrees.Count} worktree{(deletedWorktrees.Count == 1 ? string.Empty : "s")}.");
+
+        if (deletedWorktrees.Count > 0)
+        {
+            Console.WriteLine("Successfully deleted worktrees:");
+            foreach (var path in deletedWorktrees)
+                Console.WriteLine($"\t- {path}");
+        }
 
         if (deletedBranches.Count > 0)
         {
-            Console.WriteLine("Successfully deleted:");
+            Console.WriteLine("Successfully deleted branches:");
             foreach (var branchName in deletedBranches)
                 Console.WriteLine($"\t- {branchName}");
         }
 
+        if (failedWorktrees.Count > 0)
+        {
+            Console.WriteLine("Failed to delete worktrees:");
+            foreach (var failedWorktree in failedWorktrees)
+                Console.WriteLine($"\t- {failedWorktree.Path}: {failedWorktree.Error}");
+        }
+
         if (failedBranches.Count > 0)
         {
-            Console.WriteLine("Failed to delete:");
+            Console.WriteLine("Failed to delete branches:");
             foreach (var failedBranch in failedBranches)
                 Console.WriteLine($"\t- {failedBranch.Name}: {failedBranch.Error}");
         }
     }
-
-    analytics.Flush();
 }
+
+analytics.Flush();
 
 void WriteProgress(string message)
 {
@@ -301,3 +387,103 @@ void WriteProgress(string message)
         Console.WriteLine(message);
     }
 }
+
+PruneSelection ParsePruneSelection(string value)
+{
+    return value?.Trim().ToLowerInvariant() switch
+    {
+        "a" or "all" or "y" or "yes" => PruneSelection.All,
+        "w" or "worktree" or "worktrees" => PruneSelection.WorktreesOnly,
+        "b" or "branch" or "branches" => PruneSelection.BranchesOnly,
+        _ => PruneSelection.None,
+    };
+}
+
+bool TryRemoveWorktree(
+    GitWorktree worktree,
+    List<string> deletedWorktrees,
+    List<(string Path, string Error)> failedWorktrees)
+{
+    try
+    {
+        var result = GitWorktreeManager.Remove(workingDirectory, worktree.Path, settings.AlwaysForceWorktreeDeletion);
+        if (result.Succeeded)
+        {
+            analytics.TrackDeleteWorktree();
+            deletedWorktrees.Add(worktree.Path);
+            return true;
+        }
+
+        var error = GetGitError(result);
+        if (settings.AlwaysForceWorktreeDeletion)
+        {
+            failedWorktrees.Add((worktree.Path, error));
+            return false;
+        }
+
+        Console.WriteLine($"Unable to remove worktree '{worktree.Path}': {error}");
+        Console.Write("Try again with -f? y/N >");
+        if (!IsYes(Console.ReadLine()))
+        {
+            failedWorktrees.Add((worktree.Path, error));
+            return false;
+        }
+
+        var forcedResult = GitWorktreeManager.Remove(workingDirectory, worktree.Path, force: true);
+        if (!forcedResult.Succeeded)
+        {
+            failedWorktrees.Add((worktree.Path, GetGitError(forcedResult)));
+            return false;
+        }
+
+        analytics.TrackDeleteWorktree();
+        deletedWorktrees.Add(worktree.Path);
+        Console.Write("Forced removal succeeded. Always use -f when removing worktrees? y/N >");
+        if (IsYes(Console.ReadLine()))
+        {
+            settings.AlwaysForceWorktreeDeletion = true;
+            try
+            {
+                SettingsManager.SaveSettings(settings, gitDirectory);
+                Console.WriteLine("Saved AlwaysForceWorktreeDeletion: true in the repository configuration.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Removed the worktree, but could not save the force-delete preference: {ex.Message}");
+                analytics.TrackException(ex);
+            }
+        }
+
+        return true;
+    }
+    catch (Exception ex)
+    {
+        failedWorktrees.Add((worktree.Path, ex.Message));
+        analytics.TrackException(ex);
+        return false;
+    }
+}
+
+bool IsYes(string value)
+    => value?.Trim().Equals("y", StringComparison.OrdinalIgnoreCase) == true
+        || value?.Trim().Equals("yes", StringComparison.OrdinalIgnoreCase) == true;
+
+string GetGitError(GitCommandResult result)
+    => string.IsNullOrWhiteSpace(result.Error) ? result.Output.Trim() : result.Error.Trim();
+
+string DescribeBranchDeleteFailure(string branchName, GitCommandResult result)
+{
+    var gitError = GetGitError(result);
+    return $"`git branch -D -- {branchName}` exited with code {result.ExitCode}: {gitError} "
+        + "The branch may still be checked out by a linked worktree; run `git worktree list` to find it.";
+}
+
+enum PruneSelection
+{
+    None,
+    All,
+    WorktreesOnly,
+    BranchesOnly,
+}
+
+sealed record PrunableTarget(Branch Branch, GitWorktree Worktree);

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![example branch parameter](https://github.com/nolanblew/GitPrune/actions/workflows/dotnet.yml/badge.svg?branch=main)
 
 # Git Prune
-This program is intended to be an alternative `prune` method to Git's [prune](https://git-scm.com/docs/git-prune) with the intent of removing local git branches that have already been merged into GitHub (currently only supports GitHub) by querying GitHub's API to look for matching PRs that have been merged.
+This program is intended to be an alternative `prune` method to Git's [prune](https://git-scm.com/docs/git-prune) with the intent of removing local git branches and linked worktrees that have already been merged into GitHub (currently only supports GitHub) by querying GitHub's API to look for matching PRs that have been merged.
 
 The key advantage of this is that it will work even when `Squash and Merge` is the default merge-style to a branch - something that Git's `prune` functionality cannot handle as the HEAD is not present in the base branch.
 
@@ -59,6 +59,24 @@ gprune [Git Directory] [-i]
  - (Optional) `[Git Directory]`: This is the directory that contains the `git` repo you want to compare against. If not provided, your current working directory will be used
  - (Optional) `[-i]`: Use this to find out which branches _would_ be deleted without having the ability to delete them. Note: You will _always_ be prompted if you want to delete the local branches if this is not used. This will just not allow you to actually delete any branches.
 
+#### Worktrees
+
+GitPrune shows a branch checked out in a linked worktree as one item, labeled with its worktree path. It always protects both the repository's base worktree and the worktree from which it is run.
+
+When pruning, choose one of these scopes:
+
+ - `a`: delete all listed branches and worktrees. A successfully removed worktree's branch is also deleted.
+ - `w`: delete worktrees only and retain their local branches.
+ - `b`: prune ordinary local branches only, leaving every linked worktree in place.
+
+If Git refuses to remove a worktree, GitPrune offers to retry with `-f`. After a successful forced retry, it can save this repository setting in `.git/prune_config.json` (shared by every worktree):
+
+```json
+{
+  "AlwaysForceWorktreeDeletion": true
+}
+```
+
 ## Downloading
 You can find the latest packaged version in the Releases section. Tagged release workflows also upload the packaged archives plus install scripts as GitHub Actions artifacts and sync them to Azure Blob Storage for the one-line installers above.
 
@@ -74,6 +92,7 @@ Note: Local publishing helpers are available as both `publish.bat` and `publish.
 1. Clone the repo
 0. Add the `Secrets` class that implements `ISecrets` (more info below)
 0. Build/Run!
+0. Run the unit tests with `dotnet test GitPrune.Tests/GitPrune.Tests.csproj`
 0. Publish to build distributions for Windows, Mac, and Linux
 
 ## Secrets

--- a/Settings.cs
+++ b/Settings.cs
@@ -126,6 +126,7 @@ public record Settings
     public string GithubOwner { get; set; }
     public string GithubRepo { get; set; }
     public string[] BranchesToExclude { get; set; }
+    public bool AlwaysForceWorktreeDeletion { get; set; }
 }
 
 public record TokenSettings

--- a/Updater.cs
+++ b/Updater.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using Azure.Data.Tables;
 using System;
 using System.Linq;
@@ -38,7 +39,20 @@ namespace GitPrune
                 .GetTableClient("gitprune");
         }
 
-        public Version AppVersion => GetType().Assembly.GetName().Version;
+        public Version AppVersion
+        {
+            get
+            {
+                var informationalVersion = typeof(Updater).Assembly
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion;
+                var versionText = informationalVersion?.Split('+', 2)[0];
+
+                return Version.TryParse(versionText, out var version)
+                    ? version
+                    : typeof(Updater).Assembly.GetName().Version;
+            }
+        }
 
         // Cloud Table Storage
         private TableClient _tableClient;

--- a/publish.bat
+++ b/publish.bat
@@ -17,6 +17,6 @@ IF "%VERSION:~-1%" neq "b" (
 
 ECHO "Publishing version %VERSION%"
 
-dotnet publish -r win-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" %BETA% -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
-dotnet publish -r linux-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" %BETA% -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
-dotnet publish -r osx-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" %BETA% -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish GitPrune.csproj -r win-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" %BETA% -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish GitPrune.csproj -r linux-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" %BETA% -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish GitPrune.csproj -r osx-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="%VERSION%" %BETA% -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true

--- a/publish.sh
+++ b/publish.sh
@@ -17,8 +17,8 @@ fi
 
 echo "Building publish version $VERSION"
 
-dotnet publish -r win-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="$VERSION" $BETA -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
-dotnet publish -r linux-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="$VERSION" $BETA -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
-dotnet publish -r osx-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="$VERSION" $BETA -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish GitPrune.csproj -r win-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="$VERSION" $BETA -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish GitPrune.csproj -r linux-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="$VERSION" $BETA -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish GitPrune.csproj -r osx-x64 --configuration Release --self-contained true -p:PublishSingleFile=true -p:Version="$VERSION" $BETA -p:IncludeAllContentForSelfExtract=true -p:IncludeNativeLibrariesForSelfExtract=true
 
 echo "Done!"


### PR DESCRIPTION
## Summary
- detect merged branches checked out in linked worktrees and offer targeted pruning
- protect the base/current worktree, support forced removal preferences, and continue after failures
- use native Git branch deletion with actionable logged errors
- add worktree and branch deletion tests plus CI coverage

## Testing
- dotnet test GitPrune.Tests/GitPrune.Tests.csproj
- dotnet build GitPrune.csproj
- bash publish.sh 0.2.10b